### PR TITLE
Fix for client-update and an oidc client extender

### DIFF
--- a/CxPowerShift/CxPowerShift.psm1
+++ b/CxPowerShift/CxPowerShift.psm1
@@ -611,17 +611,12 @@ function Get-Clients() {
     return $this.IAMGet( "auth/admin", "clients", $params, "Failed to get clients (client id: $clientID)" )
 }
 
-function Update-ClientAttributes() {
+function Update-Client() {
     param (
-        [Parameter(Mandatory=$true)][string]$ID,
-        [Parameter(Mandatory=$true)][hashtable]$attributes
+        [Parameter(Mandatory=$true)][hashtable]$client
     )
 
-    $params = @{
-        attributes = $attributes
-    }
-
-    return $this.IAMPut( "auth/admin", "clients/$ID", @{}, $params )
+    return $this.IAMPut( "auth/admin", "clients/$($client.id)", @{}, $client )
 }
 function Get-RoleMappings() {
     param (
@@ -773,7 +768,7 @@ function NewCx1Client( $cx1url, $iamurl, $tenant, $apikey, $client_id, $client_s
         $client | Add-Member ScriptMethod -name "GetGroupByName" -Value ${function:Get-GroupByName}
         
         $client | Add-Member ScriptMethod -name "GetClients" -Value ${function:Get-Clients}
-        $client | Add-Member ScriptMethod -name "UpdateClientAttributes" -Value ${function:Update-ClientAttributes}
+        $client | Add-Member ScriptMethod -name "UpdateClient" -Value ${function:Update-Client}
         $client | Add-Member ScriptMethod -name "GetIAMRoles" -Value ${function:Get-IAMRoles}
         $client | Add-Member ScriptMethod -name "GetClientRoles" -Value ${function:Get-ClientRoles}
         $client | Add-Member ScriptMethod -name "GetGroupRoles" -Value ${function:Get-GroupRoles}

--- a/CxPowerShift/CxPowerShift.psm1
+++ b/CxPowerShift/CxPowerShift.psm1
@@ -613,10 +613,11 @@ function Get-Clients() {
 
 function Update-Client() {
     param (
-        [Parameter(Mandatory=$true)][hashtable]$client
+        [Parameter(Mandatory=$true)][pscustomobject]$client
     )
 
-    return $this.IAMPut( "auth/admin", "clients/$($client.id)", @{}, $client )
+    $clienthash = $client | ConvertTo-Json -Depth 20 | ConvertFrom-Json -AsHashTable -Depth 20
+    return $this.IAMPut( "auth/admin", "clients/$($client.id)", @{}, $clienthash )
 }
 function Get-RoleMappings() {
     param (

--- a/cxps_example_extend_oidc_expiry.ps1
+++ b/cxps_example_extend_oidc_expiry.ps1
@@ -1,0 +1,28 @@
+param(
+    $cx1url,
+    $iamurl,
+    $tenant,
+    $clientid,
+    $clientsecret,
+    $targetClientId,
+    $expiryExtension
+)
+
+Import-Module .\CxPowerShift
+
+$cx1client = NewCx1Client $cx1url $iamurl $tenant $null $clientid $clientsecret ""
+
+$clients = $cx1client.GetClients()
+
+foreach ( $client in $clients ) {
+    #Write-Host "Client $($client.clientId) has expiry $($client.attributes."client.secret.expiration.time")"
+    if ( $client.clientId -eq $targetClientId ) {
+        Write-Host "$($client.clientId) has expiry time before cutoff: $($client.attributes."client.secret.expiration.time")"
+        $expiry = [int]$client.attributes."client.secret.expiration.time" + $expiryExtension
+        Write-Host "`tUpdating this to: $expiry"
+        $client.attributes."client.secret.expiration.time" = $expiry
+        $cx1client.UpdateClient( $client )
+    }
+}
+
+Remove-Module CxPowerShift

--- a/cxps_example_fix_oidc_client_notification.ps1
+++ b/cxps_example_fix_oidc_client_notification.ps1
@@ -16,7 +16,8 @@ foreach ( $client in $clients ) {
     if ( -Not $null -eq $client.attributes.notificationEmail -and  -Not $client.attributes.notificationEmail.Contains( "[" )) {
         Write-Host "$($client.clientId) has old-format notification emails set to: $($client.attributes.notificationEmail)"
         Write-Host "`tUpdating this to: `"[`\`"$($client.attributes.notificationEmail)`\`"]`""
-        $cx1client.UpdateClientAttributes( $client.id, @{ "notificationEmail" = "[`"$($client.attributes.notificationEmail)`"]" } )
+        $client.attributes.notificationEmail = "[`"$($client.attributes.notificationEmail)`"]"
+        $cx1client.UpdateClient( $client )
     }
 
 }


### PR DESCRIPTION
Previous approach to updating clients was not correct (put with just partial content rather than full content), fixed approach updates using the full client object.
Added an example script to extend a specific oidc client expiry time by some amount.